### PR TITLE
Fix Prototype pollution

### DIFF
--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -3,7 +3,7 @@ import locale from './locale';
 export default function setLocale(custom) {
   Object.keys(custom).forEach(type => {
     if (type === '__proto__' || type === 'constructor' || type === 'prototype') {
-      throw new Error('Prototype pollution attempt detected.');
+      continue;
     }
 
     Object.keys(custom[type]).forEach(method => {

--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -7,7 +7,6 @@ export default function setLocale(custom) {
     }
 
     Object.keys(custom[type]).forEach(method => {
-      console.log({ type, method });
       locale[type][method] = custom[type][method];
     });
   });

--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -2,7 +2,7 @@ import locale from './locale';
 
 export default function setLocale(custom) {
   Object.keys(custom).forEach(type => {
-    if (type === '__proto__' || type === 'constructor' || type === 'prototype') {
+    if (type === '__proto__') {
       continue;
     }
 

--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -3,7 +3,7 @@ import locale from './locale';
 export default function setLocale(custom) {
   Object.keys(custom).forEach(type => {
     if (type === '__proto__') {
-      continue;
+      return;
     }
 
     Object.keys(custom[type]).forEach(method => {

--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -2,7 +2,7 @@ import locale from './locale';
 
 export default function setLocale(custom) {
   Object.keys(custom).forEach(type => {
-    if (type === '__proto__' || type === 'proto') {
+    if (type === '__proto__') {
       return;
     }
 

--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -2,7 +2,7 @@ import locale from './locale';
 
 export default function setLocale(custom) {
   Object.keys(custom).forEach(type => {
-    if (type === '__proto__') {
+    if (type === '__proto__' || type === 'proto') {
       return;
     }
 

--- a/src/setLocale.js
+++ b/src/setLocale.js
@@ -2,7 +2,12 @@ import locale from './locale';
 
 export default function setLocale(custom) {
   Object.keys(custom).forEach(type => {
+    if (type === '__proto__' || type === 'constructor' || type === 'prototype') {
+      throw new Error('Prototype pollution attempt detected.');
+    }
+
     Object.keys(custom[type]).forEach(method => {
+      console.log({ type, method });
       locale[type][method] = custom[type][method];
     });
   });

--- a/test/setLocale.js
+++ b/test/setLocale.js
@@ -25,10 +25,10 @@ describe('Custom locale', () => {
   });
 
   it('should not allow prototype pollution', () => {
-    const payload = JSON.parse('{"proto":{"polluted":"Yes! Its Polluted"}}');
+    const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
 
     setLocale(payload);
 
-    expect(payload).to.not.have.own.property('polluted');
+    expect(payload).to.not.have.property('polluted');
   })
 });

--- a/test/setLocale.js
+++ b/test/setLocale.js
@@ -23,4 +23,12 @@ describe('Custom locale', () => {
     const locale = require('../src/locale').default;
     expect(locale.string.email).to.equal('Invalid email');
   });
+
+  it('should not allow prototype pollution', () => {
+    const payload = JSON.parse('{"proto":{"polluted":"Yes! Its Polluted"}}');
+
+    setLocale(payload);
+
+    expect(payload).to.not.have.own.property('polluted');
+  })
 });


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-yup

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

// poc.js
let yup = require('yup');
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
yup.setLocale(payload);
console.log({}.polluted)

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/97455855-4af32100-195e-11eb-9042-3c691b9b2db7.png)

After:
![image](https://user-images.githubusercontent.com/64132745/97455927-5fcfb480-195e-11eb-8986-c5bf2c3b28b7.png)


### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected
